### PR TITLE
Testnet docs update (19-Oct)

### DIFF
--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -55,13 +55,14 @@ Before kick-starting your node, we will have to configure your node so that it c
 - Download the and replace the Croseid Testnet `genesis.json` by:
 
   ```bash
-  $ curl https://raw.githubusercontent.com/crypto-com/chain-docs-nextgen/master/docs/getting-started/assets/genesis_file/testnet-croeseid-1/genesis.json > ~/.chain-maind/config/genesis.json
+  $ curl https://raw.githubusercontent.com/crypto-com/chain-docs/master/docs/getting-started/assets/genesis_file/testnet-croeseid-1/genesis.json > ~/.chain-maind/config/genesis.json
   ```
 
-- Verify MD5 checksum of the downloaded `genesis.json`. You should see `OK!` if the MD5 checksum matches.
+- Verify sha256sum checksum of the downloaded `genesis.json`. You should see `OK!` if the MD5 checksum matches.
 
   ```bash
-  $ [ $(sha256sum genesis.json | awk '{print $1}') = "55de3738cf6a429d19e234e59e81141af2f0dfa24906d22b949728023c1af382" ] && echo "OK!" || echo "MISMATCHED"
+  $ if [[ $(sha256sum ~/.chain-maind/config/genesis.json | awk '{print $1}') = "55de3738cf6a429d19e234e59e81141af2f0dfa24906d22b949728023c1af382" ]] then echo "OK"; else echo "MISMATCHED"; fi;
+
   OK!
   ```
 
@@ -125,7 +126,7 @@ It should begin fetching blocks from the other peers. Please wait until it is fu
 For example, one can check the current block height by querying the public full node by:
 
 ```bash
-curl -s http://54.179.111.207:26657/commit | jq "{height: .result.signed_header.header.height}"
+curl -s https://testnet-croeseid-1.crypto.com:26657/commit | jq "{height: .result.signed_header.header.height}"
 ```
 
 ### Step 3-5. Send a `create-validator` transaction
@@ -135,9 +136,8 @@ Once the node is fully synced, we are now ready to send a `create-validator` tra
 ```
 $ ./chain-maind tx staking create-validator \
 --from=[name_of_your_key] \
---amount=[staking_amount i.e. 100tcro] \
---keyring-backend test \
---pubkey=[tcrocnclconspub1...]  \
+--amount=500000tcro \
+--pubkey=[tcrocnclconspub...]  \
 --moniker="[The_id_of_your_node]" \
 --security-contact="[security contact email/contact method]" \
 --chain-id="testnet-croeseid-1" \
@@ -153,9 +153,10 @@ confirm transaction before signing and broadcasting [y/N]: y
 
 You will be required to insert the following:
 
-- the `trco...` address that holds your bonded funds;
-- a moniker(name) for your validator node; and
-- [validator public key](#step-3-3-obtain-the-a-validator-public-key) with `crocnclconspub` as the prefix
+- `--from`: The `trco...` address that holds your funds;
+- `--pubkey`: The validator public key( See Step [3-3](#step-3-3-obtain-the-a-validator-public-key) above )  with **crocnclconspub** as the prefix;
+- `--moniker`: A moniker (name) for your validator node;
+- `--security-contact`: Security contact email/contact method.
 
 Now you can check if your validator has been added to the validator set:
 

--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -58,7 +58,7 @@ Before kick-starting your node, we will have to configure your node so that it c
   $ curl https://raw.githubusercontent.com/crypto-com/chain-docs/master/docs/getting-started/assets/genesis_file/testnet-croeseid-1/genesis.json > ~/.chain-maind/config/genesis.json
   ```
 
-- Verify sha256sum checksum of the downloaded `genesis.json`. You should see `OK!` if the MD5 checksum matches.
+- Verify sha256sum checksum of the downloaded `genesis.json`. You should see `OK!` if the sha256sum checksum matches.
 
   ```bash
   $ if [[ $(sha256sum ~/.chain-maind/config/genesis.json | awk '{print $1}') = "55de3738cf6a429d19e234e59e81141af2f0dfa24906d22b949728023c1af382" ]] then echo "OK"; else echo "MISMATCHED"; fi;


### PR DESCRIPTION
- Update the genesis.json link to the renamed repo;
- Generic sha256sum genesis check;
- We will be using `testnet-croeseid-1.crypto.com:26657` for basic query now. 