### PR TITLE
Problem:(Fix #42) Added more instructions and reference to chain-maind cli page in the testnet docs

### DIFF
--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -322,7 +322,7 @@ confirm transaction before signing and broadcasting [y/N]: y
 
 On the other hand, we can create a `Unbond` transaction to unbond the delegated funds
 
-::: details Example: Unbond funds from a staking address
+::: details Example: Unbond funds from a validator under the address `tcrocncl16k...edcer`
 
 ```bash
 $ chain-maind tx staking unbond tcrocncl16kqr009ptgken6qsxnzfnyjfsq6q97g3uedcer 100tcro --from Default --chain-id "testnet-croeseid-1"

--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -264,7 +264,7 @@ $ cat ~/.chain-maind_testnet/config/priv_validator_key.json | jq -r '.pub_key.va
 ## Step 4. Perform Transactions
 ### Step 4-1. `query bank balances` - Check your transferable balance
 
-You can check your _transferable_ balance with the `balance` command under the bank module.
+You can check your _transferable_ balance with the `balances ` command under the bank module.
 :::details Example: Check your address balance
 
 ```bash

--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -261,8 +261,27 @@ Alternatively, you can run it on this [browser based IDE](https://repl.it/@allth
 $ cat ~/.chain-maind_testnet/config/priv_validator_key.json | jq -r '.pub_key.value'
 ```
 
-## Step 4. Transactions subcommands
-### Step 4-1. `tx bank send ` - Transfer operation
+## Step 4. Perform Transactions
+### Step 4-1. `query bank balances` - Check your transferable balance
+
+You can check your _transferable_ balance with the `balance` command under the bank module.
+:::details Example: Check your address balance
+
+```bash
+$ chain-maind query bank balances tcro1quw5r22pxy8znjtdkgqc65atrm3x5hg6vycm5n
+
+balances:
+- amount: "10005471622381693"
+  denom: basetcro
+pagination:
+  next_key: null
+  total: "0"
+
+```
+
+:::
+
+### Step 4-2. `tx bank send ` - Transfer operation
 
 Transfer operation involves the transfer of tokens between two addresses.
 
@@ -280,7 +299,49 @@ confirm transaction before signing and broadcasting [y/N]: y
 
 :::
 
+### Step 4-3. `tx staking ` - Staking operations
+
+Staking operations involve the interaction between an address and a validator. It allows you to create a validator and lock/unlocking funds for staking purposes.
+
+#### **Delegate you funds to a validator** [`tx staking delegate <validator-addr> <amount>`]
+
+To bond funds for staking, you can deposit funds (an unspent transaction) to a _staking_ address by the `Deposit` operation.
+
+::: details Example: Delegate funds from `Default` to a validator under the address `tcrocncl16k...edcer`
+
+```bash
+$ chain-maind tx staking delegate tcrocncl16kqr009ptgken6qsxnzfnyjfsq6q97g3uedcer 100tcro --from Default --chain-id "testnet-croeseid-1"
+## Transactions payload##
+{"body":{"messages":[{"@type":"/cosmos.staking.v1beta1.MsgDelegate"....}
+confirm transaction before signing and broadcasting [y/N]: y
+```
+
+:::
+
+#### **Unbond your delegated funds** [`tx staking unbond <validator-addr> <amount>`]
+
+On the other hand, we can create a `Unbond` transaction to unbond the delegated funds
+
+::: details Example: Unbond funds from a staking address
+
+```bash
+$ chain-maind tx staking unbond tcrocncl16kqr009ptgken6qsxnzfnyjfsq6q97g3uedcer 100tcro --from Default --chain-id "testnet-croeseid-1"
+## Transaction payload##
+{"body":{"messages":[{"@type":"/cosmos.staking.v1beta1.MsgUndelegate"...}
+confirm transaction before signing and broadcasting [y/N]: y
+```
+
+:::
+
+::: tip
+
+- Once your funds were unbonded, It will be locked until the `unbonding_time` has passed.
+
+:::
+
+Congratulations! You've successfully setup a Testnet node and performed some of the basic transactions! You may refer to [Wallet Management](https://chain.crypto.com/docs/wallets/cli.html#chain-maind) for more advanced operations and transactions.
+
 ## Croeseid testnet faucet
 
 - To interact with the blockchain, simply use the [CRO faucet](https://chain.crypto.com/faucet) to obtain test CRO tokens for performing transactions on the **Croseid** testnet.
-  - Note that you will need to create an [address](#step-3-1-create-a-new-key-and-address) before using the faucet.
+  - Note that you will need to create an [address](#step-3-1-create-a-new-key-and-address) before using the faucet. 

--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -305,7 +305,7 @@ Staking operations involve the interaction between an address and a validator. I
 
 #### **Delegate you funds to a validator** [`tx staking delegate <validator-addr> <amount>`]
 
-To bond funds for staking, you can deposit funds (an unspent transaction) to a _staking_ address by the `Deposit` operation.
+To bond funds for staking, you can delegate funds  to a validator by the `delegate` command
 
 ::: details Example: Delegate funds from `Default` to a validator under the address `tcrocncl16k...edcer`
 

--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -264,7 +264,7 @@ $ cat ~/.chain-maind_testnet/config/priv_validator_key.json | jq -r '.pub_key.va
 ## Step 4. Perform Transactions
 ### Step 4-1. `query bank balances` - Check your transferable balance
 
-You can check your _transferable_ balance with the `balances ` command under the bank module.
+You can check your _transferable_ balance with the `balances` command under the bank module.
 :::details Example: Check your address balance
 
 ```bash
@@ -305,7 +305,7 @@ Staking operations involve the interaction between an address and a validator. I
 
 #### **Delegate you funds to a validator** [`tx staking delegate <validator-addr> <amount>`]
 
-To bond funds for staking, you can delegate funds  to a validator by the `delegate` command
+To bond funds for staking, you can delegate funds to a validator by the `delegate` command
 
 ::: details Example: Delegate funds from `Default` to a validator under the address `tcrocncl16k...edcer`
 

--- a/docs/getting-started/local-devnet.md
+++ b/docs/getting-started/local-devnet.md
@@ -100,7 +100,7 @@ You can also specify some of the network parameters in the genesis file of your 
 
 Once we finish with the configuration, we are ready to start the chain: in the repository root directory, run
 
-```
+```sh
 $ pystarport serve --config examples/devnet.yaml
 ```
 
@@ -121,6 +121,12 @@ Kindly save these mnemonics for key recovery later.
 
 Blocks is now being generated! You can view the blockchain data by the rpc port of the `awesome0` (first node): [http://localhost:26657/](http://localhost:26657/).
 Futhermore, you can also use the swagger doc of `awesome0` at [http://localhost:26654/swagger/](http://localhost:26654/swagger/).
+
+It is worth mentioning that the `serve` command would truncate all the blocks previously generated and regenerate a new genesis block, which means you'll also lose all of your transaction records. If you wish to restart the chain with the existing blocks, please run `pystarport` with `start` command:
+
+```sh
+$ pystarport start
+```
 
 ## Interact with the chain
 

--- a/docs/wallets/cli.md
+++ b/docs/wallets/cli.md
@@ -240,7 +240,7 @@ Staking operations involve the interaction between an address and a validator. I
 
 #### **Delegate you funds to a validator** [`tx staking delegate <validator-addr> <amount>`]
 
-To bond funds for staking, you can deposit funds (an unspent transaction) to a _staking_ address by the `Deposit` operation.
+To bond funds for staking, you can delegate funds to a validator by the `delegate` command
 
 ::: details Example: Delegate funds from `Default` to a validator under the address `crocncl1zd...rz35z`
 
@@ -257,7 +257,7 @@ confirm transaction before signing and broadcasting [y/N]: y
 
 On the other hand, we can create a `Unbond` transaction to unbond the delegated funds
 
-::: details Example: Unbond funds from a staking address
+::: details Example: Unbond funds from a validator under the address `crocncl1zdl...rz35z`
 
 ```bash
 $ chain-maind tx staking unbond crocncl1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s3prz35z 100cro --from Default --chain-id cro-test
@@ -278,7 +278,7 @@ confirm transaction before signing and broadcasting [y/N]: y
 
 ### `query bank balances` - Check your transferable balance
 
-You can check your _transferable_ balance with the `balance` command under the bank module.
+You can check your _transferable_ balance with the `balances` command under the bank module.
 :::details Example: Check your address balance
 
 ```bash


### PR DESCRIPTION
Instead of adding un-jail instruction, added instructions of transfer, staking & query balance. A note is also added at the end for redirecting people to chain-maind cli page.