### PR TITLE
Croeseid testnet getting-started: update create-validator transaction

### DIFF
--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -219,7 +219,7 @@ Once the node is fully synced, we are now ready to send a `create-validator` tra
 ```
 $ ./chain-maind tx staking create-validator \
 --from=[name_of_your_key] \
---amount=500000tcro \
+--amount=1tcro \
 --pubkey=[tcrocnclconspub...]  \
 --moniker="[The_id_of_your_node]" \
 --security-contact="[security contact email/contact method]" \
@@ -227,7 +227,8 @@ $ ./chain-maind tx staking create-validator \
 --commission-rate="0.10" \
 --commission-max-rate="0.20" \
 --commission-max-change-rate="0.01" \
---min-self-delegation="1"
+--min-self-delegation="1" \
+--gas-prices 0.1basetcro
 
 {"body":{"messages":[{"@type":"/cosmos.staking.v1beta1.MsgCreateValidator"...}
 confirm transaction before signing and broadcasting [y/N]: y

--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -228,7 +228,8 @@ $ ./chain-maind tx staking create-validator \
 --commission-max-rate="0.20" \
 --commission-max-change-rate="0.01" \
 --min-self-delegation="1" \
---gas-prices 0.1basetcro
+--gas auto \
+--gas-adjustment=1.5
 
 {"body":{"messages":[{"@type":"/cosmos.staking.v1beta1.MsgCreateValidator"...}
 confirm transaction before signing and broadcasting [y/N]: y

--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -219,7 +219,7 @@ Once the node is fully synced, we are now ready to send a `create-validator` tra
 ```
 $ ./chain-maind tx staking create-validator \
 --from=[name_of_your_key] \
---amount=1tcro \
+--amount=500000tcro \
 --pubkey=[tcrocnclconspub...]  \
 --moniker="[The_id_of_your_node]" \
 --security-contact="[security contact email/contact method]" \


### PR DESCRIPTION
For me and other members of the community on [Discord](https://discord.com/channels/783264383978569728/783264902613565450/789208334800388127),  we needed to add `gas-prices` to fix the `insufficient fee` error. 

Also, since we get 10 test CRO per day on the faucet,  I reduced the amount of the `create-validator` transaction, since a low amount worked for me.