### PR TITLE
Problem: (fix#100) Testnet docs is not updated to v0.8.1

### DIFF
--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -26,13 +26,13 @@ To run Crypto.com Chain nodes, you will need a machine with the following minimu
 ## Step 1. Get the Crypto.com Chain binary
 
 To simplify the following step, we will be using **Linux** for illustration. Binary for
-[Mac](https://github.com/crypto-com/chain-main/releases/download/v0.8.0-croeseid/chain-main_0.8.0-croeseid_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-com/chain-main/releases/download/v0.8.0-croeseid/chain-main_0.8.0-croeseid_Windows_x86_64.zip) are also available.
+[Mac](https://github.com/crypto-com/chain-main/releases/download/v0.8.1-croeseid/chain-main_0.8.1-croeseid_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-com/chain-main/releases/download/v0.8.1-croeseid/chain-main_0.8.1-croeseid_Windows_x86_64.zip) are also available.
 
 - To install Crypto.com Chain released binaries from github:
 
   ```bash
-  $ curl -LOJ https://github.com/crypto-com/chain-main/releases/download/v0.8.0-croeseid/chain-main_0.8.0-croeseid_Linux_x86_64.tar.gz
-  $ tar -zxvf chain-main_0.8.0-croeseid_Linux_x86_64.tar.gz
+  $ curl -LOJ https://github.com/crypto-com/chain-main/releases/download/v0.8.1-croeseid/chain-main_0.8.1-croeseid_Linux_x86_64.tar.gz
+  $ tar -zxvf chain-main_0.8.1-croeseid_Linux_x86_64.tar.gz
   ```
 
   OR

--- a/docs/getting-started/testnet-aws-1click.md
+++ b/docs/getting-started/testnet-aws-1click.md
@@ -198,11 +198,11 @@ If you haven't installed `chain-maind` yet, please follow [Step 1. Get the Crypt
 
 ```bash
 $ chain-maind version
-0.8.0-croeseid
+0.8.1-croeseid
 ```
 
 - Testnet binary for
-  [Mac](https://github.com/crypto-com/chain-main/releases/download/v0.8.0-croeseid/chain-main_0.8.0-croeseid_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-com/chain-main/releases/download/v0.8.0-croeseid/chain-main_0.8.0-croeseid_Windows_x86_64.zip) are also available.
+  [Mac](https://github.com/crypto-com/chain-main/releases/download/v0.8.1-croeseid/chain-main_0.8.1-croeseid_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-com/chain-main/releases/download/v0.8.1-croeseid/chain-main_0.8.1-croeseid_Windows_x86_64.zip) are also available.
   :::
 
 ### Step 4-1. Create a new key and address

--- a/docs/getting-started/testnet-azure-1click.md
+++ b/docs/getting-started/testnet-azure-1click.md
@@ -205,7 +205,7 @@ $ chain-maind version
 ```
 
 - Testnet binary for
-  [Mac](https://github.com/crypto-com/chain-main/releases/download/v0.8.0-croeseid/chain-main_0.8.0-croeseid_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-com/chain-main/releases/download/v0.8.0-croeseid/chain-main_0.8.0-croeseid_Windows_x86_64.zip) are also available.
+  [Mac](https://github.com/crypto-com/chain-main/releases/download/v0.8.1-croeseid/chain-main_0.8.1-croeseid_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-com/chain-main/releases/download/v0.8.1-croeseid/chain-main_0.8.1-croeseid_Windows_x86_64.zip) are also available.
   :::
 
 ### Step 4-1. Create a new key and address


### PR DESCRIPTION
Solution:
- Update the "Getting started" and "1-Click" contents to v0.8.1-croeseid. 