### PR TITLE
Update Solo Machine Content under Nav Bar

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -207,7 +207,6 @@ module.exports = {
             "Notes on Production Deployment": 19,
             "Threat Model": 20,
             "technical_glossary": 21
-            "solo_machine": 22
             
           };
           return ordering[a["title"]] - ordering[b["title"]];

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -107,15 +107,19 @@ module.exports = {
               {
                 text: "Integrating Crypto.org Chain ",
                 link: "/resources/chain-integration"
-            },              
-                {
-                    text: "Technical Glossary",
-                    link: "/resources/technical-glossary"
-                },
-                {
-                  text: "gRPC API",
-                  link: "/resources/cosmos-grpc-docs"
-              }               
+              },              
+              {
+                text: "Technical Glossary",
+                link: "/resources/technical-glossary"
+              },
+              {
+                text: "gRPC API",
+                link: "/resources/cosmos-grpc-docs"
+              },     
+              {
+                text: "Solo Machine",
+                link: "/resources/solo-machine"
+              }       
             ]
         }
     ],
@@ -203,6 +207,7 @@ module.exports = {
             "Notes on Production Deployment": 19,
             "Threat Model": 20,
             "technical_glossary": 21
+            "solo-machine": 22
             
           };
           return ordering[a["title"]] - ordering[b["title"]];

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -206,7 +206,8 @@ module.exports = {
             "Notes on Performance": 18,
             "Notes on Production Deployment": 19,
             "Threat Model": 20,
-            "technical_glossary": 21
+            "technical-glossary": 21,
+            "solo-machine": 22
             
           };
           return ordering[a["title"]] - ordering[b["title"]];

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -207,7 +207,7 @@ module.exports = {
             "Notes on Production Deployment": 19,
             "Threat Model": 20,
             "technical_glossary": 21
-            "solo-machine": 22
+            "solo_machine": 22
             
           };
           return ordering[a["title"]] - ordering[b["title"]];


### PR DESCRIPTION
Added solo machine content at https://github.com/crypto-org-chain/chain-docs/pull/282, also to add it to the navigation bar under "Resources."

Signed-off-by: Anthea <78806365+aw126@users.noreply.github.com>