### PR TITLE
Display Solo Machine Content under Nav Bar

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -115,7 +115,11 @@ module.exports = {
                 {
                   text: "gRPC API",
                   link: "/resources/cosmos-grpc-docs"
-              }               
+                },
+                {
+                  text: "Solo Machine",
+                  link: "/resources/solo-machine"
+                }     
             ]
         }
     ],
@@ -202,7 +206,8 @@ module.exports = {
             "Notes on Performance": 18,
             "Notes on Production Deployment": 19,
             "Threat Model": 20,
-            "technical_glossary": 21
+            "technical-glossary": 21,
+            "solo-machine": 22
             
           };
           return ordering[a["title"]] - ordering[b["title"]];


### PR DESCRIPTION
Add Solo Machine to the navigation bar under "Resources"

Signed-off-by: Anthea <78806365+aw126@users.noreply.github.com>